### PR TITLE
[PIDM-2099] SPECS: Add new endpoint to massively retrieve transactions actions

### DIFF
--- a/api-spec/v2/openapi.yaml
+++ b/api-spec/v2/openapi.yaml
@@ -86,6 +86,59 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /v2/deadletter-transactions/actions:
+    post:
+      description: >
+        [GET with body payload](https://opensource.zalando.com/restful-api-guidelines/#get-with-body)
+        - no resources created: Returns all actions matching the transactionIds passed as request input payload.
+      tags:
+        - deadletter-transactions-actions
+      summary: List actions for a list of deadletter transaction
+      operationId: listActionsForDeadletterTransaction
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: TransactionIds actions to retrieve
+        required: true
+        content:
+          application/json:
+            schema:
+              description: List of transactionIds
+              type: array
+              minItems: 1
+              items:
+                type: string
+      responses:
+        '200':
+          description: List of actions taken on the list of deadletter transactions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/DeadletterTransactionAction'
+        '400':
+          description: Invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '401':
+          description: Unauthorized. Missing or invalid authentication token.
+        '404':
+          description: Deadletter transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
 components:
   securitySchemes:
     bearerAuth:
@@ -151,6 +204,39 @@ components:
         - pspId
         - eCommerceStatus
         - deadletterTransactionDetails
+    DeadletterTransactionAction:
+      type: object
+      properties:
+        id:
+          type: string
+        transactionId:
+          type: string
+        userId:
+          type: string
+        action:
+          $ref: '#/components/schemas/ActionType'
+        timestamp:
+          type: string
+          format: date-time
+      required:
+        - id
+        - transactionId
+        - userId
+        - action
+        - timestamp
+    ActionType:
+      type: object
+      properties:
+        value:
+          type: string
+        type:
+          type: string
+          enum:
+            - "FINAL"
+            - "NOT_FINAL"
+      required:
+        - value
+        - type
     ProblemJson:
       type: object
       properties:

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v2/WatchdogDeadletterV2Controller.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v2/WatchdogDeadletterV2Controller.kt
@@ -3,11 +3,13 @@ package it.pagopa.ecommerce.watchdog.deadletter.controllers.v2
 import it.pagopa.ecommerce.watchdog.deadletter.services.AuthService
 import it.pagopa.ecommerce.watchdog.deadletter.services.DeadletterTransactionsService
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.api.V2Api
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.DeadletterTransactionActionDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.ListDeadletterTransactions200ResponseDto
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,6 +18,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 @RestController("WatchdogDeadletterV2Controller")
@@ -26,6 +29,13 @@ class WatchdogDeadletterV2Controller(
 ) : V2Api {
 
     private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    override fun listActionsForDeadletterTransaction(
+        requestBody: @Valid @Size(min = 1) Flux<String?>?,
+        exchange: ServerWebExchange?,
+    ): Mono<ResponseEntity<Flux<List<DeadletterTransactionActionDto?>?>?>?>? {
+        TODO("Not yet implemented")
+    }
 
     override fun listDeadletterTransactions(
         @RequestParam("fromDate") @NotNull @Valid fromDate: LocalDate,


### PR DESCRIPTION
#### List of Changes
Add a new endpoint specs to massively retrieve transactions actions

#### Motivation and Context
Currently the frontend is forced to make one call for each transactions to retrieve its respective actions, which is suboptimal.

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.