### PR TITLE
[PIDM-2103] Decoupled entity actiontype from dto

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/config/ActionTypeConfig.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/config/ActionTypeConfig.kt
@@ -1,7 +1,6 @@
 package it.pagopa.ecommerce.watchdog.deadletter.config
 
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
-import java.util.ArrayList
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
@@ -9,5 +8,5 @@ import org.springframework.context.annotation.Configuration
 @ConfigurationProperties(prefix = "actiontype")
 class ActionTypeConfig {
 
-    var types: List<ActionTypeDto> = ArrayList()
+    var types: List<ActionType> = ArrayList()
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/ActionController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/ActionController.kt
@@ -21,6 +21,8 @@ class ActionController(@Autowired val actionService: ActionService) : ActionsApi
     override fun listActions(
         exchange: ServerWebExchange?
     ): Mono<ResponseEntity<Flux<ActionTypeDto>?>> {
-        return Mono.just(ResponseEntity.ok(actionService.getActionType()))
+        return Mono.just(
+            ResponseEntity.ok(actionService.getActionType().map { it.toDto<ActionTypeDto>() })
+        )
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -3,6 +3,7 @@ package it.pagopa.ecommerce.watchdog.deadletter.controllers.v1
 import it.pagopa.ecommerce.watchdog.deadletter.services.AuthService
 import it.pagopa.ecommerce.watchdog.deadletter.services.DeadletterTransactionsService
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.api.DeadletterTransactionsApi
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionActionDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionActionInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ListDeadletterTransactions200ResponseDto
@@ -113,7 +114,7 @@ class WatchdogDeadletterController(
                             it.id,
                             it.transactionId,
                             it.userId,
-                            it.action,
+                            it.action.toDto<ActionTypeDto>(),
                             it.timestamp.atOffset(ZoneOffset.UTC),
                         )
                     }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/Action.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/Action.kt
@@ -1,6 +1,5 @@
 package it.pagopa.ecommerce.watchdog.deadletter.documents
 
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
 import java.time.Instant
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
@@ -10,6 +9,6 @@ data class Action(
     @Id val id: String,
     val transactionId: String,
     val userId: String,
-    val action: ActionTypeDto,
+    val action: ActionType,
     val timestamp: Instant,
 )

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/ActionType.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/ActionType.kt
@@ -1,0 +1,30 @@
+package it.pagopa.ecommerce.watchdog.deadletter.documents
+
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto as DtoV1
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.ActionTypeDto as DtoV2
+
+data class ActionType(val value: String, val type: Type) {
+    enum class Type {
+        FINAL,
+        NOT_FINAL,
+    }
+
+    companion object {
+        inline fun <reified T> fromDto(dto: T): ActionType {
+            return when (dto) {
+                is DtoV1 -> ActionType(dto.value, Type.valueOf(dto.type.name))
+                is DtoV2 -> ActionType(dto.value, Type.valueOf(dto.type.name))
+                else -> throw IllegalArgumentException("not a valid data type ${T::class}")
+            }
+        }
+    }
+
+    inline fun <reified T> toDto(): T {
+        return when (T::class) {
+            DtoV1::class -> DtoV1(this.value, DtoV1.TypeEnum.valueOf(this.type.name))
+            DtoV2::class -> DtoV2(this.value, DtoV2.TypeEnum.valueOf(this.type.name))
+            else -> throw IllegalArgumentException("not a valid data type ${T::class}")
+        }
+            as T
+    }
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/ActionService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/ActionService.kt
@@ -1,7 +1,7 @@
 package it.pagopa.ecommerce.watchdog.deadletter.services
 
 import it.pagopa.ecommerce.watchdog.deadletter.config.ActionTypeConfig
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
@@ -9,7 +9,7 @@ import reactor.core.publisher.Flux
 @Service
 class ActionService(@Autowired val actionTypeConfig: ActionTypeConfig) {
 
-    fun getActionType(): Flux<ActionTypeDto> {
+    fun getActionType(): Flux<ActionType> {
         return Flux.fromIterable(actionTypeConfig.types)
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
@@ -4,6 +4,7 @@ import it.pagopa.ecommerce.watchdog.deadletter.clients.EcommerceHelpdeskServiceC
 import it.pagopa.ecommerce.watchdog.deadletter.clients.NodoTechnicalSupportClient
 import it.pagopa.ecommerce.watchdog.deadletter.config.ActionTypeConfig
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Note
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidActionValue
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
@@ -19,12 +20,8 @@ import it.pagopa.generated.ecommerce.helpdesk.model.SearchNpgOperationsResponseD
 import it.pagopa.generated.ecommerce.helpdesk.model.TransactionResultDto as TransactionResultDtoV2
 import it.pagopa.generated.ecommerce.helpdesk.model.TransactionResultDto
 import it.pagopa.generated.ecommerce.helpdesk.model.UserInfoDto
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionDto
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.*
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ListDeadletterTransactions200ResponseDto as ListDeadletterTransactions200ResponseDtoV1
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteDto
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.PageInfoDto
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.TransactionNotesDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.DeadletterTransactionDto as DeadletterTransactionDtoV2
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.ListDeadletterTransactions200ResponseDto as ListDeadletterTransactions200ResponseDtoV2
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.PageInfoDto as PageInfoDtoV2
@@ -445,23 +442,23 @@ class DeadletterTransactionsService(
         actionValue: String,
     ): Mono<Action> {
 
-        val actionTypeDto: ActionTypeDto? = actionTypeConfig.types.find { actionValue in it.value }
-        if (actionTypeDto != null) {
-            return ecommerceHelpdeskServiceV1
+        val actionType: ActionType? = actionTypeConfig.types.find { actionValue in it.value }
+        return if (actionType == null) Mono.error(InvalidActionValue())
+        else
+            ecommerceHelpdeskServiceV1
                 .searchTransactions(transactionId)
-                .flatMap { _ ->
-                    val newAction =
+                .flatMap {
+                    deadletterTransactionActionRepository.save(
                         Action(
                             id = UUID.randomUUID().toString(),
                             transactionId = transactionId,
                             userId = userId,
-                            action = actionTypeDto,
+                            action = actionType,
                             timestamp = Instant.now(),
                         )
-                    deadletterTransactionActionRepository.save(newAction)
+                    )
                 }
                 .switchIfEmpty(Mono.error(InvalidTransactionId()))
-        } else return Mono.error(InvalidActionValue())
     }
 
     fun listActionsForDeadletterTransaction(transactionId: String, userId: String): Flux<Action> {

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/ActionControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/ActionControllerTest.kt
@@ -1,6 +1,7 @@
 package it.pagopa.ecommerce.watchdog.deadletter.controllers.v1
 
 import it.pagopa.ecommerce.watchdog.deadletter.config.TestSecurityConfig
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import it.pagopa.ecommerce.watchdog.deadletter.services.ActionService
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
 import kotlin.test.assertEquals
@@ -28,8 +29,8 @@ class ActionControllerTest {
 
     @Test
     fun `listActions should return 200 OKAY with the list of the action available`() {
-        val actionTypesList: ArrayList<ActionTypeDto> = ArrayList()
-        actionTypesList.add(ActionTypeDto("test1", ActionTypeDto.TypeEnum.NOT_FINAL))
+        val actionTypesList: ArrayList<ActionType> = ArrayList()
+        actionTypesList.add(ActionType("test1", ActionType.Type.NOT_FINAL))
 
         // For catch the generic type during the Test
         val listType = object : ParameterizedTypeReference<List<ActionTypeDto>>() {}

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
@@ -2,6 +2,7 @@ package it.pagopa.ecommerce.watchdog.deadletter.controllers.v1
 
 import it.pagopa.ecommerce.watchdog.deadletter.config.TestSecurityConfig
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidTransactionId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.NotesLimitException
@@ -41,7 +42,7 @@ class WatchdogDeadletterControllerTest {
         val deadletterTransactionActionInputDto =
             DeadletterTransactionActionInputDto("testActionValue")
 
-        val action = ActionTypeDto("testActionValue", ActionTypeDto.TypeEnum.NOT_FINAL)
+        val action = ActionType("testActionValue", ActionType.Type.NOT_FINAL)
 
         given(
                 deadletterTransactionsService.addActionToDeadletterTransaction(
@@ -249,7 +250,7 @@ class WatchdogDeadletterControllerTest {
     fun `list actions for deadletter transaction should return '200 OKAY' and return the list of action in the body`() {
         val deadletterTransactionId: String = "00000000"
         val userId: String = "test-user"
-        val actionType = ActionTypeDto("testActionValue", ActionTypeDto.TypeEnum.NOT_FINAL)
+        val actionType = ActionType("testActionValue", ActionType.Type.NOT_FINAL)
         val action: Action =
             Action("test-id", deadletterTransactionId, userId, actionType, Instant.now())
 

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/domain/ActionTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/domain/ActionTest.kt
@@ -1,0 +1,48 @@
+package it.pagopa.ecommerce.watchdog.deadletter.domain
+
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto as DtoV1
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v2.model.ActionTypeDto as DtoV2
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest
+@TestPropertySource(locations = ["classpath:application.test.properties"])
+class ActionTest {
+
+    @Test
+    fun `fromDto should return the ActionType from ActionTypeDto for any dto version`() {
+        val actionTypeDtoV1 = DtoV1("TEST", DtoV1.TypeEnum.FINAL)
+        val actionTypeDtoV2 = DtoV2("TEST", DtoV2.TypeEnum.FINAL)
+
+        val actionTypeV1 = ActionType.fromDto(actionTypeDtoV1)
+        val actionTypeV2 = ActionType.fromDto(actionTypeDtoV2)
+
+        assertEquals(actionTypeV1.value, actionTypeDtoV1.value)
+        assertEquals(actionTypeV1.type.name, actionTypeDtoV1.type.name)
+
+        assertEquals(actionTypeV2.value, actionTypeDtoV2.value)
+        assertEquals(actionTypeV2.type.name, actionTypeDtoV2.type.name)
+
+        assertThrows<IllegalArgumentException> { ActionType.fromDto("Test") }
+    }
+
+    @Test
+    fun `toDto should return the ActionTypeDto related to ActionType based on dto version`() {
+        val actionType = ActionType("TEST", ActionType.Type.FINAL)
+
+        val actionTypeDtoV1 = actionType.toDto<DtoV1>()
+        val actionTypeDtoV2 = actionType.toDto<DtoV2>()
+
+        assertEquals(actionTypeDtoV1.value, actionType.value)
+        assertEquals(actionTypeDtoV1.type.name, actionType.type.name)
+
+        assertEquals(actionTypeDtoV2.value, actionType.value)
+        assertEquals(actionTypeDtoV2.type.name, actionType.type.name)
+
+        assertThrows<IllegalArgumentException> { actionType.toDto<String>() }
+    }
+}

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/ActionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/ActionServiceTest.kt
@@ -1,6 +1,6 @@
 package it.pagopa.ecommerce.watchdog.deadletter.services
 
-import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,14 +15,10 @@ class ActionServiceTest {
     @Autowired private lateinit var actionService: ActionService
 
     @Test
-    fun `getActionType should return the Flux of ActionTypeDto with the ActionType available`() {
+    fun `getActionType should return the Flux of ActionType with the ActionType available`() {
         StepVerifier.create(actionService.getActionType())
             .assertNext { action ->
-                assertEquals(
-                    action.type,
-                    ActionTypeDto.TypeEnum.FINAL,
-                    "The action type is not the same",
-                )
+                assertEquals(action.type, ActionType.Type.FINAL, "The action type is not the same")
                 assertEquals(
                     action.value,
                     "Nessuna azione richiesta",

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
@@ -4,6 +4,7 @@ import it.pagopa.ecommerce.watchdog.deadletter.clients.EcommerceHelpdeskServiceC
 import it.pagopa.ecommerce.watchdog.deadletter.clients.NodoTechnicalSupportClient
 import it.pagopa.ecommerce.watchdog.deadletter.config.ActionTypeConfig
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
+import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Note
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidActionValue
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
@@ -665,9 +666,9 @@ class DeadletterTransactionServiceTest {
     fun `addActionToDeadletterTransaction should save a deadletterTransactionAction`() {
         val transactionId = "testId"
         val userId = "userIdTest"
-        val actionValueType = ActionTypeDto("test", ActionTypeDto.TypeEnum.NOT_FINAL)
+        val actionValueType = ActionType("test", ActionType.Type.NOT_FINAL)
         val actionValue = "test"
-        val actionTypes = listOf<ActionTypeDto>(actionValueType)
+        val actionTypes = listOf(actionValueType)
         actionConfig.types = actionTypes
 
         val action =
@@ -711,8 +712,8 @@ class DeadletterTransactionServiceTest {
         val userId = "userIdTest"
         val actionValueType = ActionTypeDto("test", ActionTypeDto.TypeEnum.NOT_FINAL)
         val actionValue = "wrong-value"
-        val actionTypes = listOf<ActionTypeDto>(actionValueType)
-        actionConfig.types = actionTypes
+        val actionTypes = listOf(actionValueType)
+        actionConfig.types = actionTypes.map { ActionType.fromDto(it) }
 
         val resultMono =
             deadletterTransactionsService.addActionToDeadletterTransaction(
@@ -731,7 +732,7 @@ class DeadletterTransactionServiceTest {
         val actionValueType = ActionTypeDto("test", ActionTypeDto.TypeEnum.NOT_FINAL)
         val actionValue = "test"
         val actionTypes = listOf<ActionTypeDto>(actionValueType)
-        actionConfig.types = actionTypes
+        actionConfig.types = actionTypes.map { ActionType.fromDto(it) }
 
         whenever(ecommerceHelpdeskServiceV1.searchTransactions(any())).thenReturn(Mono.empty())
 
@@ -749,7 +750,7 @@ class DeadletterTransactionServiceTest {
     fun `listActionsForDeadletterTransaction should return all the action associated with a certain transactionId`() {
         val transactionId = "testId"
         val userId = "userIdTest"
-        val actionValueType = ActionTypeDto("test", ActionTypeDto.TypeEnum.NOT_FINAL)
+        val actionValueType = ActionType("test", ActionType.Type.NOT_FINAL)
 
         val action: Action =
             Action(


### PR DESCRIPTION
#### List of Changes
Decoupled entity and dto ActionType with all the resulting changes needed to preserve the behavior

#### Motivation and Context
This change was required because the internal representation of an entity shouldn't be dependent on it's representation to client.
If kept as-is, it would require me to implement convertion method from v2 to v1 for no apparent reason.

There are coverage errors because of a Jacoco behavior with inline functions + reified generics, more info here:
https://github.com/jacoco/jacoco/issues/1873

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.