### PR TITLE
[PIDM-2234] Added new massive action operation endpoint

### DIFF
--- a/api-spec/v1/openapi.yaml
+++ b/api-spec/v1/openapi.yaml
@@ -168,6 +168,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /deadletter-transactions/actions/bulk:
+    post:
+      tags:
+        - deadletter-transactions-actions
+      summary: Add a new action to multiple deadletter transactions
+      operationId: addActionToDeadletterTransactions
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: Action to be added
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeadletterTransactionsActionInput'
+      responses:
+        '201':
+          description: Action added successfully
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '401':
+          description: Unauthorized. Missing or invalid authentication token.
+        '404':
+          description: Deadletter transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /deadletter-transactions/{transactionId}/notes:
     post:
       tags:
@@ -577,6 +615,17 @@ components:
     DeadletterTransactionActionInput:
       type: object
       properties:
+        value:
+          type: string
+      required:
+        - value
+    DeadletterTransactionsActionInput:
+      type: object
+      properties:
+        transactionIds:
+          type: array
+          items:
+            type: string
         value:
           type: string
       required:

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -6,6 +6,7 @@ import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.api.DeadletterTransa
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ActionTypeDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionActionDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionActionInputDto
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionsActionInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ListDeadletterTransactions200ResponseDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteInputDto
@@ -53,6 +54,13 @@ class WatchdogDeadletterController(
                 }
             }
             .thenReturn(ResponseEntity.created(URI("")).build())
+    }
+
+    override fun addActionToDeadletterTransactions(
+        deadletterTransactionsActionInputDto: @Valid Mono<DeadletterTransactionsActionInputDto>,
+        exchange: ServerWebExchange,
+    ): Mono<ResponseEntity<Void>> {
+        TODO("Not yet implemented")
     }
 
     override fun addNoteToDeadletterTransaction(


### PR DESCRIPTION
#### List of Changes
Added new endpoint to add an action to multiple transactions

#### Motivation and Context
As requested, it may happen that multiple transactions need the same actions.
To avoid making one API call for each transaction, I've added this endpoint.

In particular, there's a bit of a philosophical question regarding it's name /addActions, which was not chosen casually.
The reason is that soon will also be added an endpoint to add a note to multiple transactions, but it has a collision with an already existing endpoint if we use resource naming convention.

The TL;DR / current situation is this
|         | POST (GET with body)           | POST (single)                                    | POST (massive) |
|---------|--------------------------------|--------------------------------------------------|----------------|
| Actions |                -               | /deadletter-transactions/{transactionId}/actions |       **???**      |
| Notes   | /deadletter-transactions/notes | /deadletter-transactions/{transactionId}/notes   |       **???**      |


I've reached these possible conclusions:
1. Name this endpoint /addActions and the next one /addNotes to avoid collision

|         | POST (GET with body)           | POST (single)                                    | POST (massive)                      |
|---------|--------------------------------|--------------------------------------------------|-------------------------------------|
| Actions |                -               | /deadletter-transactions/{transactionId}/actions | **/deadletter-transactions/addActions** |
| Notes   | /deadletter-transactions/notes | /deadletter-transactions/{transactionId}/notes   | **/deadletter-transactions/addNotes**   |

PROs:
- No collisions
- Preserves previous endpoint name
- Coherent naming

CONs:
- Not using resource naming convention

2. Name this endpoint /actions and the next one /addNotes to avoid collision

|         | POST (GET with body)           | POST (single)                                    | POST (massive)                    |
|---------|--------------------------------|--------------------------------------------------|-----------------------------------|
| Actions |                -               | /deadletter-transactions/{transactionId}/actions | **/deadletter-transactions/actions**  |
| Notes   | /deadletter-transactions/notes | /deadletter-transactions/{transactionId}/notes   | **/deadletter-transactions/addNotes** |

PROs:
- No collisions
- Preserves previous endpoint name

CONs:
- Not using resource naming convention
- Naming not coherent

3. Name the previous endpoint /getNotes and use resource naming convention for the next ones

|         | POST (GET with body)              | POST (single)                                    | POST (massive)                   |
|---------|-----------------------------------|--------------------------------------------------|----------------------------------|
| Actions |                 -                 | /deadletter-transactions/{transactionId}/actions | **/deadletter-transactions/actions** |
| Notes   | **/deadletter-transactions/getNotes** | /deadletter-transactions/{transactionId}/notes   | **/deadletter-transactions/notes**   |

PROs:
- No collisions
- Uses resource naming convention (which also means it's coherent)

CONs:
- Does NOT preserve previous endpoint name

If I have to choose the one that requires less effort, it would be option 1.
If I have to choose the "optimal" one, it would be option 3 or 4.

Please let me know what do you think.


#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.