### PR TITLE
[PIDM-2235] Added new massive notes endpoint spec (+ small validation fix on massive actions)

### DIFF
--- a/api-spec/v1/openapi.yaml
+++ b/api-spec/v1/openapi.yaml
@@ -355,6 +355,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /deadletter-transactions/notes/bulk:
+    post:
+      tags:
+        - deadletter-transaction-notes
+      summary: Add a new note to multiple deadletter transactions
+      operationId: addNoteToDeadletterTransactions
+      security:
+        - bearerAuth: []
+      requestBody:
+        description: The text of the note
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotesInput'
+      responses:
+        '201':
+          description: Notes added successfully
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '401':
+          description: Unauthorized. Missing or invalid authentication token.
+        '404':
+          description: Deadletter transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '422':
+          description: Unprocessable entity. Number of notes already equal to the limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /deadletter-transactions/notes:
     post:
       tags:
@@ -585,6 +629,21 @@ components:
           maxLength: 300
       required:
         - note
+    NotesInput:
+      type: object
+      properties:
+        transactionIds:
+          type: array
+          items:
+            type: string
+            minItems: 1
+        note:
+          type: string
+          minLength: 1
+          maxLength: 300
+      required:
+        - transactionIds
+        - note
     NotesRequest:
       type: object
       properties:
@@ -626,9 +685,11 @@ components:
           type: array
           items:
             type: string
+            minItems: 1
         value:
           type: string
       required:
+        - transactionIds
         - value
     AuthenticationCredentials:
       type: object

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -10,6 +10,7 @@ import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTran
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ListDeadletterTransactions200ResponseDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteInputDto
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NotesInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NotesRequestDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.TransactionNotesDto
 import jakarta.validation.Valid
@@ -89,6 +90,13 @@ class WatchdogDeadletterController(
                     }
             }
         }
+    }
+
+    override fun addNoteToDeadletterTransactions(
+        noteInputDto: @Valid Mono<NotesInputDto>,
+        exchange: ServerWebExchange,
+    ): Mono<ResponseEntity<Void>> {
+        TODO("Not yet implemented")
     }
 
     override fun deleteNoteDeadletterTransaction(

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
@@ -142,9 +142,7 @@ class WatchdogDeadletterControllerTest {
         val deadletterTransactionIds = listOf("00000000", "00000001")
         val userId = "test-user"
         val action = ActionType("Nessuna azione richiesta", ActionType.Type.FINAL)
-        val input =
-            DeadletterTransactionsActionInputDto(action.value)
-                .transactionIds(deadletterTransactionIds)
+        val input = DeadletterTransactionsActionInputDto(deadletterTransactionIds, action.value)
 
         given(deadletterTransactionsService.addActionToDeadletterTransactions(input, userId))
             .willReturn(
@@ -186,8 +184,10 @@ class WatchdogDeadletterControllerTest {
         val deadletterTransactionIds = listOf("00000000", "00000001")
         val userId = "test-user"
         val input =
-            DeadletterTransactionsActionInputDto("Nessuna azione richiesta")
-                .transactionIds(deadletterTransactionIds)
+            DeadletterTransactionsActionInputDto(
+                deadletterTransactionIds,
+                "Nessuna azione richiesta",
+            )
 
         given(authService.getAuthenticatedUserId()).willReturn(Mono.just(userId))
         given(deadletterTransactionsService.addActionToDeadletterTransactions(input, userId))

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
@@ -766,7 +766,7 @@ class DeadletterTransactionServiceTest {
                 Action(UUID.randomUUID().toString(), it, userId, actionValueType, Instant.now())
             }
 
-        val input = DeadletterTransactionsActionInputDto(actionValue).transactionIds(transactionIds)
+        val input = DeadletterTransactionsActionInputDto(transactionIds, actionValue)
 
         whenever(ecommerceHelpdeskServiceV1.searchTransactions(any()))
             .thenReturn(Mono.just(SearchTransactionResponseDto()))
@@ -806,7 +806,7 @@ class DeadletterTransactionServiceTest {
         val actionTypes = listOf(actionValueType)
         actionConfig.types = actionTypes.map { ActionType.fromDto(it) }
 
-        val input = DeadletterTransactionsActionInputDto(actionValue).transactionIds(transactionIds)
+        val input = DeadletterTransactionsActionInputDto(transactionIds, actionValue)
 
         val resultMono =
             deadletterTransactionsService.addActionToDeadletterTransactions(input, userId)
@@ -825,7 +825,7 @@ class DeadletterTransactionServiceTest {
 
         whenever(ecommerceHelpdeskServiceV1.searchTransactions(any())).thenReturn(Mono.empty())
 
-        val input = DeadletterTransactionsActionInputDto(actionValue).transactionIds(transactionIds)
+        val input = DeadletterTransactionsActionInputDto(transactionIds, actionValue)
         val resultMono =
             deadletterTransactionsService.addActionToDeadletterTransactions(input, userId)
 


### PR DESCRIPTION
#### List of Changes
As title describes and as described in the PR #70, added a new endpoint to massively add a note to multiple transactions.
Also fixed the massive action endpoint to require the existance of the transactionIds with at least 1 element.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.