### PR TITLE
[PIDM-2275] Added new stats endpoint spec + some minItems fixes

### DIFF
--- a/api-spec/v1/openapi.yaml
+++ b/api-spec/v1/openapi.yaml
@@ -441,6 +441,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /deadletter-transactions/stats:
+    get:
+      tags:
+        - deadletter-transactions
+      summary: Get action stats of a given month on a day-by-day detail
+      operationId: getStats
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: year
+          in: query
+          required: true
+          description: The year to analyze
+          schema:
+            type: integer
+            minimum: 2000
+            maximum: 3000
+            example: 2026
+        - name: month
+          in: query
+          required: true
+          description: The month to analyze
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 7
+      responses:
+        '200':
+          description: List of day by day statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonthStatsResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
   /authenticate:
     post:
       tags:
@@ -640,9 +680,9 @@ components:
       properties:
         transactionIds:
           type: array
+          minItems: 1
           items:
             type: string
-            minItems: 1
         note:
           type: string
           minLength: 1
@@ -677,6 +717,30 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/TransactionNotes'
+    MonthStatsResponse:
+      type: object
+      properties:
+        stats:
+          type: array
+          items:
+            type: object
+            properties:
+              date:
+                type: string
+                format: date
+              finalized:
+                type: integer
+                minimum: 0
+              notFinalized:
+                type: integer
+                minimum: 0
+              notAnalyzed:
+                type: integer
+                minimum: 0
+                nullable: true
+            required:
+              - value
+              - type
     DeadletterTransactionActionInput:
       type: object
       properties:
@@ -689,9 +753,9 @@ components:
       properties:
         transactionIds:
           type: array
+          minItems: 1
           items:
             type: string
-            minItems: 1
         value:
           type: string
       required:

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -8,6 +8,7 @@ import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTran
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionActionInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.DeadletterTransactionsActionInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.ListDeadletterTransactions200ResponseDto
+import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.MonthStatsResponseDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NoteInputDto
 import it.pagopa.generated.ecommerce.watchdog.deadletter.v1.model.NotesInputDto
@@ -183,5 +184,13 @@ class WatchdogDeadletterController(
                 }
                 .thenReturn(ResponseEntity.status(204).build())
         }
+    }
+
+    override fun getStats(
+        year: @NotNull @Min(value = 2000) @Max(value = 3000) @Valid Int,
+        month: @NotNull @Min(value = 1) @Max(value = 12) @Valid Int,
+        exchange: ServerWebExchange?,
+    ): Mono<ResponseEntity<MonthStatsResponseDto>> {
+        TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
#### List of Changes
- Added a new endpoint which will return the transaction stats in a given year/month
- Fixed some minItems misplacements causing warnings when using openapi-generator

#### Motivation and Context
This endpoint will be needed to develop the calendar which will give "at a glance" informations to users for each day of a selected month.

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.