### PR TITLE
[PIDM-2276] Monthly statistics implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,7 +237,10 @@ tasks.register("generate") { dependsOn(tasks.matching { it.group == "openapi-gen
 
 tasks.withType<KotlinCompile> {
   dependsOn("watchdog-v1", "ecommerce-helpdesk-service", "nodo-technical-support", "watchdog-v2")
-  compilerOptions { jvmTarget.set(JvmTarget.JVM_21) }
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_21)
+    freeCompilerArgs.add("-Xjvm-default=all")
+  }
 }
 
 tasks.test {

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -42,7 +42,7 @@ class WatchdogDeadletterController(
 
     override fun addActionToDeadletterTransaction(
         deadletterTransactionId: String,
-        deadletterTransactionActionInputDto: @Valid Mono<DeadletterTransactionActionInputDto>,
+        @Valid deadletterTransactionActionInputDto: Mono<DeadletterTransactionActionInputDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<Void>> {
         return deadletterTransactionActionInputDto
@@ -59,7 +59,7 @@ class WatchdogDeadletterController(
     }
 
     override fun addActionToDeadletterTransactions(
-        deadletterTransactionsActionInputDto: @Valid Mono<DeadletterTransactionsActionInputDto>,
+        @Valid deadletterTransactionsActionInputDto: Mono<DeadletterTransactionsActionInputDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<Void>> {
         return deadletterTransactionsActionInputDto
@@ -76,7 +76,7 @@ class WatchdogDeadletterController(
 
     override fun addNoteToDeadletterTransaction(
         transactionId: String,
-        noteInputDto: @Valid Mono<NoteInputDto>,
+        @Valid noteInputDto: Mono<NoteInputDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<NoteDto>> {
         /*
@@ -94,7 +94,7 @@ class WatchdogDeadletterController(
     }
 
     override fun addNoteToDeadletterTransactions(
-        notesInputDto: @Valid Mono<NotesInputDto>,
+        @Valid notesInputDto: Mono<NotesInputDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<Flux<NoteDto>>> {
         return notesInputDto
@@ -124,7 +124,7 @@ class WatchdogDeadletterController(
     }
 
     override fun getNotesByTransactionIdList(
-        notesRequestDto: @Valid Mono<NotesRequestDto>,
+        @Valid notesRequestDto: Mono<NotesRequestDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<Flux<TransactionNotesDto>>> {
         logger.info("Received getNotesByTransactionIdList request")
@@ -173,7 +173,7 @@ class WatchdogDeadletterController(
     override fun updateNoteDeadletterTransaction(
         transactionId: String,
         noteId: String,
-        noteInputDto: @Valid Mono<NoteInputDto>,
+        @Valid noteInputDto: Mono<NoteInputDto>,
         exchange: ServerWebExchange,
     ): Mono<ResponseEntity<Void>> {
         logger.info("Received update request for note: [{}] ", noteId)
@@ -187,8 +187,8 @@ class WatchdogDeadletterController(
     }
 
     override fun getStats(
-        year: @NotNull @Min(value = 2000) @Max(value = 3000) @Valid Int,
-        month: @NotNull @Min(value = 1) @Max(value = 12) @Valid Int,
+        @NotNull @Min(value = 2000) @Max(value = 3000) @Valid year: Int,
+        @NotNull @Min(value = 1) @Max(value = 12) @Valid month: Int,
         exchange: ServerWebExchange?,
     ): Mono<ResponseEntity<MonthStatsResponseDto>> {
         TODO("Not yet implemented")

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterController.kt
@@ -191,6 +191,8 @@ class WatchdogDeadletterController(
         @NotNull @Min(value = 1) @Max(value = 12) @Valid month: Int,
         exchange: ServerWebExchange?,
     ): Mono<ResponseEntity<MonthStatsResponseDto>> {
-        TODO("Not yet implemented")
+        return deadletterTransactionsService.getDailyStats(year, month).map {
+            ResponseEntity.ok(it)
+        }
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/DayStats.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/DayStats.kt
@@ -1,0 +1,14 @@
+package it.pagopa.ecommerce.watchdog.deadletter.documents
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Version
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "notes")
+data class DayStats(
+    @Id val date: String,
+    val finalized: Int,
+    val notFinalized: Int,
+    val notAnalyzed: Int?,
+    @Version val version: Int,
+)

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/repositories/DayStatsRepository.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/repositories/DayStatsRepository.kt
@@ -1,0 +1,21 @@
+package it.pagopa.ecommerce.watchdog.deadletter.repositories
+
+import it.pagopa.ecommerce.watchdog.deadletter.documents.DayStats
+import java.time.YearMonth
+import org.springframework.data.mongodb.repository.Query
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
+
+@Repository
+interface DayStatsRepository : ReactiveCrudRepository<DayStats, String> {
+
+    @Query("{'admission_date': {\$gte: ?0, \$lte: ?1}}")
+    fun getBetweenDates(from: String, to: String): Flux<DayStats>
+
+    fun getBetweenDates(year: Int, month: Int): Flux<DayStats> {
+        val from = YearMonth.of(year, month).atDay(1)
+        val to = YearMonth.of(year, month).atEndOfMonth()
+        return getBetweenDates(from.toString(), to.toString())
+    }
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidActionValue
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidTransactionId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.NotesLimitException
+import it.pagopa.ecommerce.watchdog.deadletter.repositories.DayStatsRepository
 import it.pagopa.ecommerce.watchdog.deadletter.repositories.DeadletterTransactionActionRepository
 import it.pagopa.ecommerce.watchdog.deadletter.repositories.DeadletterTransactionNoteRepository
 import it.pagopa.ecommerce.watchdog.deadletter.utils.ObfuscationUtils.obfuscateEmail
@@ -52,6 +53,7 @@ class DeadletterTransactionsService(
     private val nodoTechnicalSupportClient: NodoTechnicalSupportClient,
     private val deadletterTransactionActionRepository: DeadletterTransactionActionRepository,
     private val deadletterTransactionNoteRepository: DeadletterTransactionNoteRepository,
+    private val dayStatsRepository: DayStatsRepository,
     @Autowired val actionTypeConfig: ActionTypeConfig,
     @Value("\${note.numlimit}") private val noteNumLimitConfig: Long,
     @Value("\${note.update.limittime.minutes}") private val noteUpdateLimitTime: Long,
@@ -665,5 +667,23 @@ class DeadletterTransactionsService(
                     Mono.error(InvalidNoteId())
                 }
             }
+    }
+
+    fun getDailyStats(year: Int, month: Int): Mono<MonthStatsResponseDto> {
+        val stats = dayStatsRepository.getBetweenDates(year, month)
+
+        return stats.collectList().map {
+            val result = MonthStatsResponseDto()
+            it.forEach { stat ->
+                result.addStatsItem(
+                    MonthStatsResponseStatsInnerDto()
+                        .date(LocalDate.parse(stat.date))
+                        .finalized(stat.finalized)
+                        .notFinalized(stat.notFinalized)
+                        .notAnalyzed(stat.notAnalyzed)
+                )
+            }
+            return@map result
+        }
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
@@ -434,9 +434,12 @@ class WatchdogDeadletterControllerTest {
             .isEqualTo(422)
     }
 
+    @Test
     fun `add a new note to multiple transactions`() {
 
-        val notesInputDto = NotesInputDto(listOf("transactionId1", "transactionId2"), "noteText")
+        val transactionIds = listOf("transactionId1", "transactionId2")
+
+        val notesInputDto = NotesInputDto(transactionIds, "noteText")
         val notesDto =
             Flux.just(
                 NoteDto(
@@ -462,7 +465,7 @@ class WatchdogDeadletterControllerTest {
                 deadletterTransactionsService.addNoteToDeadLetterTransactions(
                     "noteText",
                     "userId",
-                    listOf("transactionId1", "transactionId1"),
+                    transactionIds,
                 )
             )
             .willReturn(notesDto)
@@ -477,6 +480,7 @@ class WatchdogDeadletterControllerTest {
             .isCreated
     }
 
+    @Test
     fun `add a new note to multiple transaction should return a error 404 because the transaction doesnt exist`() {
 
         val notesInputDto = NotesInputDto(listOf("transactionId1", "transactionId2"), "noteText")

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/controllers/v1/WatchdogDeadletterControllerTest.kt
@@ -14,6 +14,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
+import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.context.annotation.Import
@@ -634,5 +635,60 @@ class WatchdogDeadletterControllerTest {
             .exchange()
             .expectStatus()
             .isNotFound
+    }
+
+    @Test
+    fun `get stats should return '200 OKAY' with the stats of the month`() {
+        given(authService.getAuthenticatedUserId()).willReturn(Mono.just("userId"))
+        given(deadletterTransactionsService.getDailyStats(any(), any()))
+            .willReturn(Mono.just(MonthStatsResponseDto()))
+
+        webClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/deadletter-transactions/stats")
+                    .queryParam("year", 2026)
+                    .queryParam("month", 7)
+                    .build()
+            }
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+    }
+
+    @Test
+    fun `get stats should return '400 BAD REQUEST' when required params are missing`() {
+        given(authService.getAuthenticatedUserId()).willReturn(Mono.just("userId"))
+
+        webClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder.path("/deadletter-transactions/stats").queryParam("month", 7).build()
+            }
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `get stats should return '400 BAD REQUEST' when required params are out of range`() {
+        given(authService.getAuthenticatedUserId()).willReturn(Mono.just("userId"))
+        given(deadletterTransactionsService.getDailyStats(any(), any()))
+            .willReturn(Mono.just(MonthStatsResponseDto()))
+
+        webClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/deadletter-transactions/stats")
+                    .queryParam("year", 3026)
+                    .queryParam("month", 13)
+                    .build()
+            }
+            .exchange()
+            .expectStatus()
+            .isBadRequest
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
@@ -5,11 +5,13 @@ import it.pagopa.ecommerce.watchdog.deadletter.clients.NodoTechnicalSupportClien
 import it.pagopa.ecommerce.watchdog.deadletter.config.ActionTypeConfig
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
 import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
+import it.pagopa.ecommerce.watchdog.deadletter.documents.DayStats
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Note
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidActionValue
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidTransactionId
 import it.pagopa.ecommerce.watchdog.deadletter.exception.NotesLimitException
+import it.pagopa.ecommerce.watchdog.deadletter.repositories.DayStatsRepository
 import it.pagopa.ecommerce.watchdog.deadletter.repositories.DeadletterTransactionActionRepository
 import it.pagopa.ecommerce.watchdog.deadletter.repositories.DeadletterTransactionNoteRepository
 import it.pagopa.generated.ecommerce.helpdesk.model.DeadLetterEventDto
@@ -58,12 +60,14 @@ class DeadletterTransactionServiceTest {
         mock()
     private val actionConfig: ActionTypeConfig = ActionTypeConfig()
     private val deadletterTransactionsNoteRepo: DeadletterTransactionNoteRepository = mock()
+    private val dayStatsRepository: DayStatsRepository = mock()
     private val deadletterTransactionsService: DeadletterTransactionsService =
         DeadletterTransactionsService(
             ecommerceHelpdeskServiceV1,
             nodoTechnicalSupportClient,
             deadletterTransactionActionRepository,
             deadletterTransactionsNoteRepo,
+            dayStatsRepository,
             actionConfig,
             noteNumLimit,
             noteUpdateLimitTime,
@@ -1529,6 +1533,28 @@ class DeadletterTransactionServiceTest {
             .expectNextMatches { response ->
                 response.deadletterTransactions[0].gatewayAuthorizationStatus == "EXECUTED"
             }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getDailyStats should return MonthStatsResponse with elements if they are present`() {
+
+        whenever(dayStatsRepository.getBetweenDates(any<Int>(), any<Int>()))
+            .thenReturn(Flux.just(DayStats("2026-07-01", 1, 0, 0, 0)))
+
+        StepVerifier.create(deadletterTransactionsService.getDailyStats(2026, 7))
+            .expectNextMatches { it.stats.size == 1 && it.stats[0].finalized == 1 }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getDailyStats should return MonthStatsResponse with no elements if they are not present`() {
+
+        whenever(dayStatsRepository.getBetweenDates(any<Int>(), any<Int>()))
+            .thenReturn(Flux.empty())
+
+        StepVerifier.create(deadletterTransactionsService.getDailyStats(2026, 7))
+            .expectNextMatches { it.stats.isEmpty() }
             .verifyComplete()
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
@@ -307,7 +307,7 @@ class DeadletterTransactionServiceTest {
     }
 
     @Test
-    fun `getDeadletterTransactions should return an empy ListDeadletterTransactions200ResponseDto because of the searchNpgOperations error`() {
+    fun `getDeadletterTransactions should return an empty ListDeadletterTransactions200ResponseDto because of the searchNpgOperations error`() {
         val date: LocalDate = LocalDate.parse("2025-08-19")
         val pageNumber: Int = 0
         val pageSize: Int = 1


### PR DESCRIPTION
#### List of Changes
1. Added stats endpoint implementation
2. Fixed some unit tests which were not annotated with `@Test`
3. Added jvm-default compiler flag to enable transpilation to interface default methods.

#### Motivation and Context
1. Required to allow frontend calendar coloring based on transaction action status
2. Self explanatory
3. Without this, creating methods with implementations inside interfaces would cause an error especially when defined inside a `@Repository` annotated interface. It is also suggested for codebases which do not work with Java 8 or older.
(More info [here](https://kotlinlang.org/docs/java-to-kotlin-interop.html#no-compatibility) which refers to new names since kotlin 2.2, but the behaviour is mostly the same)

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.