### PR TITLE
[PIDM-2298] Added create/update stats on add action

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/DayStats.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/documents/DayStats.kt
@@ -1,5 +1,6 @@
 package it.pagopa.ecommerce.watchdog.deadletter.documents
 
+import java.time.LocalDate
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Version
 import org.springframework.data.mongodb.core.mapping.Document
@@ -11,4 +12,44 @@ data class DayStats(
     val notFinalized: Int,
     val notAnalyzed: Int?,
     @Version val version: Int,
-)
+) {
+    companion object {
+        fun createFrom(action: ActionType, date: LocalDate = LocalDate.now()): DayStats {
+            var finalized = 0
+            var notFinalized = 0
+
+            when (action.type) {
+                ActionType.Type.FINAL -> finalized += 1
+                ActionType.Type.NOT_FINAL -> notFinalized += 1
+            }
+
+            return DayStats(date.toString(), finalized, notFinalized, null, 0)
+        }
+    }
+
+    fun transition(old: ActionType.Type?, new: ActionType.Type): DayStats {
+        var finalized = this.finalized
+        var notFinalized = this.notFinalized
+        var notAnalyzed = this.notAnalyzed
+
+        when (old to new) {
+            ActionType.Type.NOT_FINAL to ActionType.Type.FINAL -> {
+                notFinalized -= 1
+                finalized += 1
+            }
+            ActionType.Type.FINAL to ActionType.Type.NOT_FINAL -> {
+                notFinalized += 1
+                finalized -= 1
+            }
+            null to ActionType.Type.FINAL -> {
+                notAnalyzed = notAnalyzed?.minus(1)
+                finalized += 1
+            }
+            null to ActionType.Type.NOT_FINAL -> {
+                notAnalyzed = notAnalyzed?.minus(1)
+                notFinalized += 1
+            }
+        }
+        return DayStats(this.date, finalized, notFinalized, notAnalyzed, this.version)
+    }
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/repositories/DeadletterTransactionActionRepository.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/repositories/DeadletterTransactionActionRepository.kt
@@ -4,6 +4,7 @@ import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Repository
 interface DeadletterTransactionActionRepository : ReactiveCrudRepository<Action, String> {
@@ -11,4 +12,6 @@ interface DeadletterTransactionActionRepository : ReactiveCrudRepository<Action,
     fun findByTransactionId(transactionId: String): Flux<Action>
 
     fun findAllByTransactionIdIn(transactionIds: List<String>): Flux<Action>
+
+    fun findFirstByTransactionIdOrderByTimestampDesc(transactionId: String): Mono<Action>
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionsService.kt
@@ -5,6 +5,7 @@ import it.pagopa.ecommerce.watchdog.deadletter.clients.NodoTechnicalSupportClien
 import it.pagopa.ecommerce.watchdog.deadletter.config.ActionTypeConfig
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Action
 import it.pagopa.ecommerce.watchdog.deadletter.documents.ActionType
+import it.pagopa.ecommerce.watchdog.deadletter.documents.DayStats
 import it.pagopa.ecommerce.watchdog.deadletter.documents.Note
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidActionValue
 import it.pagopa.ecommerce.watchdog.deadletter.exception.InvalidNoteId
@@ -453,15 +454,20 @@ class DeadletterTransactionsService(
             ecommerceHelpdeskServiceV1
                 .searchTransactions(transactionId)
                 .flatMap {
-                    deadletterTransactionActionRepository.save(
-                        Action(
-                            id = UUID.randomUUID().toString(),
-                            transactionId = transactionId,
-                            userId = userId,
-                            action = actionType,
-                            timestamp = Instant.now(),
+                    val result =
+                        deadletterTransactionActionRepository.save(
+                            Action(
+                                id = UUID.randomUUID().toString(),
+                                transactionId = transactionId,
+                                userId = userId,
+                                action = actionType,
+                                timestamp = Instant.now(),
+                            )
                         )
-                    )
+
+                    updateStats(transactionId, it.transactions, actionType).subscribe()
+
+                    return@flatMap result
                 }
                 .switchIfEmpty(Mono.error(InvalidTransactionId()))
     }
@@ -478,21 +484,24 @@ class DeadletterTransactionsService(
                 .flatMap { tId ->
                     ecommerceHelpdeskServiceV1
                         .searchTransactions(tId)
+                        .map { tId to it }
                         .switchIfEmpty(Mono.error(InvalidTransactionId()))
-                        .thenReturn(tId)
                 }
-                .map { tId ->
-                    deadletterTransactionActionRepository.save(
-                        Action(
-                            id = UUID.randomUUID().toString(),
-                            transactionId = tId,
-                            userId = userId,
-                            action = actionType,
-                            timestamp = Instant.now(),
+                .flatMap { tId ->
+                    val result =
+                        deadletterTransactionActionRepository.save(
+                            Action(
+                                id = UUID.randomUUID().toString(),
+                                transactionId = tId.first,
+                                userId = userId,
+                                action = actionType,
+                                timestamp = Instant.now(),
+                            )
                         )
-                    )
+
+                    updateStats(tId.first, tId.second.transactions, actionType).subscribe()
+                    return@flatMap result
                 }
-                .flatMap { it }
                 .collectList()
     }
 
@@ -685,5 +694,29 @@ class DeadletterTransactionsService(
             }
             return@map result
         }
+    }
+
+    fun updateStats(
+        transactionId: String,
+        transactions: List<TransactionResultDto>,
+        newAction: ActionType,
+    ): Flux<DayStats> {
+        return transactions
+            .filter { it.transactionInfo != null && it.transactionInfo.creationDate != null }
+            .map { transaction ->
+                dayStatsRepository
+                    .findById(transaction.transactionInfo.creationDate?.toLocalDate().toString())
+                    .flatMap { stats ->
+                        deadletterTransactionActionRepository
+                            .findFirstByTransactionIdOrderByTimestampDesc(transactionId)
+                            .map { prevAction ->
+                                stats.transition(prevAction.action.type, newAction.type)
+                            }
+                            .defaultIfEmpty(stats.transition(null, newAction.type))
+                    }
+                    .defaultIfEmpty(DayStats.createFrom(newAction))
+            }
+            .let { Flux.merge(it) }
+            .let { dayStatsRepository.saveAll(it) }
     }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/watchdog/deadletter/services/DeadletterTransactionServiceTest.kt
@@ -44,6 +44,7 @@ import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import org.mockito.kotlin.argumentCaptor
+import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
@@ -692,6 +693,9 @@ class DeadletterTransactionServiceTest {
         whenever(ecommerceHelpdeskServiceV1.searchTransactions(any()))
             .thenReturn(Mono.just(SearchTransactionResponseDto()))
         whenever(deadletterTransactionActionRepository.save(any())).thenReturn(Mono.just(action))
+        whenever(dayStatsRepository.saveAll(any<Publisher<DayStats>>())).thenAnswer {
+            Flux.from(it.getArgument<Publisher<DayStats>>(0))
+        }
 
         val resultMono =
             deadletterTransactionsService.addActionToDeadletterTransaction(
@@ -777,6 +781,10 @@ class DeadletterTransactionServiceTest {
 
         whenever(deadletterTransactionActionRepository.save(any())).thenAnswer {
             Mono.just(it.getArgument<Action>(0))
+        }
+
+        whenever(dayStatsRepository.saveAll(any<Publisher<DayStats>>())).thenAnswer {
+            Flux.from(it.getArgument<Publisher<DayStats>>(0))
         }
 
         val resultMono =
@@ -1555,6 +1563,149 @@ class DeadletterTransactionServiceTest {
 
         StepVerifier.create(deadletterTransactionsService.getDailyStats(2026, 7))
             .expectNextMatches { it.stats.isEmpty() }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `updateStats should create daily stats based on transactions passed when no stat exists`() {
+
+        val tInfo = TransactionInfoDto().apply { creationDate = OffsetDateTime.now().minusDays(1) }
+        val transaction = TransactionResultDto().apply { transactionInfo = tInfo }
+
+        whenever(
+                deadletterTransactionActionRepository.findFirstByTransactionIdOrderByTimestampDesc(
+                    any<String>()
+                )
+            )
+            .thenReturn(Mono.empty())
+        whenever(dayStatsRepository.findById(any<String>())).thenReturn(Mono.empty())
+        whenever(dayStatsRepository.saveAll(any<Publisher<DayStats>>())).thenAnswer {
+            Flux.from(it.getArgument<Publisher<DayStats>>(0))
+        }
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.NOT_FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == 1 && it.finalized == 0 && it.notAnalyzed == null
+            }
+            .verifyComplete()
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == 0 && it.finalized == 1 && it.notAnalyzed == null
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `updateStats should update daily stats based on transactions passed when previous action exists`() {
+
+        val mockStats = DayStats(LocalDate.now().toString(), 1, 2, 3, 1)
+        val pInfo = PaymentInfoDto().apply { idTransaction = "test1" }
+        val tInfo = TransactionInfoDto().apply { creationDate = OffsetDateTime.now().minusDays(1) }
+        val transaction =
+            TransactionResultDto().apply {
+                paymentInfo = pInfo
+                transactionInfo = tInfo
+            }
+        val previousActionNotF =
+            Action(
+                "testAction",
+                "test1",
+                "user1",
+                ActionType("ActionValue", ActionType.Type.NOT_FINAL),
+                Instant.now().minusSeconds(60 * 60 * 24),
+            )
+
+        val previousActionF =
+            Action(
+                "testAction",
+                "test1",
+                "user1",
+                ActionType("ActionValue", ActionType.Type.FINAL),
+                Instant.now().minusSeconds(60 * 60 * 24),
+            )
+
+        whenever(
+                deadletterTransactionActionRepository.findFirstByTransactionIdOrderByTimestampDesc(
+                    any<String>()
+                )
+            )
+            .thenReturn(Mono.just(previousActionNotF))
+            .thenReturn(Mono.just(previousActionF))
+            .thenReturn(Mono.empty())
+            .thenReturn(Mono.empty())
+
+        whenever(dayStatsRepository.findById(any<String>())).thenReturn(Mono.just(mockStats))
+        whenever(dayStatsRepository.saveAll(any<Publisher<DayStats>>())).thenAnswer {
+            Flux.from(it.getArgument<Publisher<DayStats>>(0))
+        }
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == mockStats.notFinalized - 1 &&
+                    it.finalized == mockStats.finalized + 1 &&
+                    it.notAnalyzed == mockStats.notAnalyzed
+            }
+            .verifyComplete()
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.NOT_FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == mockStats.notFinalized + 1 &&
+                    it.finalized == mockStats.finalized - 1 &&
+                    it.notAnalyzed == mockStats.notAnalyzed
+            }
+            .verifyComplete()
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.NOT_FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == mockStats.notFinalized + 1 &&
+                    it.finalized == mockStats.finalized &&
+                    it.notAnalyzed == mockStats.notAnalyzed?.minus(1)
+            }
+            .verifyComplete()
+
+        StepVerifier.create(
+                deadletterTransactionsService.updateStats(
+                    "test1",
+                    listOf(transaction),
+                    ActionType("testAction", ActionType.Type.FINAL),
+                )
+            )
+            .thenConsumeWhile {
+                it.notFinalized == mockStats.notFinalized &&
+                    it.finalized == mockStats.finalized + 1 &&
+                    it.notAnalyzed == mockStats.notAnalyzed?.minus(1)
+            }
             .verifyComplete()
     }
 }


### PR DESCRIPTION
#### List of Changes
Added logic to create/update daily stats on add action

#### Motivation and Context

The `findFirstByTransactionIdOrderByTimestampDesc` query was added to the action repository because when updating the stats, we need to know which was the previous last action that was assigned to that specific transaction.
This way we can update correctly the stats like, for example:
- A `FINAL` action was assigned to a previously latest `NOT_FINAL`, this means that there will be one more `FINAL` and one less `NOT_FINAL`
- A transaction with no previous action (marked as `NOT_ANALYZED`) now receives a `NOT_FINAL` action, which means there will be one less `NOT_ANALYZED` and one more `NOT_FINAL`

**This query won't work on Cosmos DB specifically UNLESS an index is present on the timestamp field.**

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.